### PR TITLE
adds default UTF-8 encoding

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-dinky
+encoding: UTF-8


### PR DESCRIPTION
Not sure if this will apply to static text files, or just to .md files; worth a shot!