### PR TITLE
Fix ac:options typos

### DIFF
--- a/tests-wood/ixml-20220222/hygiene-tests.xml
+++ b/tests-wood/ixml-20220222/hygiene-tests.xml
@@ -1,5 +1,6 @@
 <tc:test-catalog xmlns:tc="https://github.com/cmsmcq/ixml-tests"
 		 xmlns:ap="http://blackmesatech.com/2019/iXML/Aparecium"
+                 xmlns:ixml="http://invisiblexml.org/NS"
 		 release-date="2022-03-12"
 		 name="Improper grammars">
   <tc:description>
@@ -269,17 +270,17 @@
 	<tc:options ap:undefined-nonterminals="warning"/>
 	<tc:options ap:undefined-nonterminals="silence"/>	
 	<tc:assert-xml>
-	  <S><B>b</B></S>
+	  <S ixml:state="ambiguous"><B>b</B></S>
 	</tc:assert-xml><tc:assert-xml>
-	  <S><B><B>b</B></B></S>
+	  <S ixml:state="ambiguous"><B><B>b</B></B></S>
 	</tc:assert-xml><tc:assert-xml>
-	  <S><B><B><B>b</B></B></B></S>
+	  <S ixml:state="ambiguous"><B><B><B>b</B></B></B></S>
 	</tc:assert-xml><tc:assert-xml>
-	  <S><B><B><B><B>b</B></B></B></B></S>
+	  <S ixml:state="ambiguous"><B><B><B><B>b</B></B></B></B></S>
 	</tc:assert-xml><tc:assert-xml>
-	  <S><B><B><B><B><B>b</B></B></B></B></B></S>
+	  <S ixml:state="ambiguous"><B><B><B><B><B>b</B></B></B></B></B></S>
 	</tc:assert-xml><tc:assert-xml>
-	  <S><B><B><B><B><B><B>b</B></B></B></B></B></B></S>
+	  <S ixml:state="ambiguous"><B><B><B><B><B><B>b</B></B></B></B></B></B></S>
 	</tc:assert-xml>
       </tc:app-info>
     </tc:test-case>
@@ -293,7 +294,7 @@
 	<tc:options ap:undefined-nonterminals="warning"/>
 	<tc:options ap:undefined-nonterminals="silence"/>
 	<tc:assert-xml>
-	  <S>(<S>a</S>)</S>
+	  <S>(<S><A>a</A></S>)</S>
 	</tc:assert-xml>
       </tc:app-info>
     </tc:test-case>
@@ -307,7 +308,7 @@
 	<tc:options ap:undefined-nonterminals="warning"/>
 	<tc:options ap:undefined-nonterminals="silence"/>
 	<tc:assert-xml>
-	  <S>(<S>(<S>a</S>)</S>)</S>
+	  <S>(<S>(<S><A>a</A></S>)</S>)</S>
 	</tc:assert-xml>
       </tc:app-info>
     </tc:test-case>

--- a/tests-wood/ixml-20220222/hygiene-tests.xml
+++ b/tests-wood/ixml-20220222/hygiene-tests.xml
@@ -116,8 +116,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:multiple-definitions="warning"/>
-	<ap:options ap:multiple-definitions="silence"/>
+	<tc:options ap:multiple-definitions="warning"/>
+	<tc:options ap:multiple-definitions="silence"/>
 	<tc:assert-not-a-sentence/>
       </tc:app-info>
     </tc:test-case>
@@ -128,8 +128,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:multiple-definitions="warning"/>
-	<ap:options ap:multiple-definitions="silence"/>
+	<tc:options ap:multiple-definitions="warning"/>
+	<tc:options ap:multiple-definitions="silence"/>
 	<tc:assert-xml>
 	  <S>a</S>
 	</tc:assert-xml>
@@ -142,8 +142,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:multiple-definitions="warning"/>
-	<ap:options ap:multiple-definitions="silence"/>
+	<tc:options ap:multiple-definitions="warning"/>
+	<tc:options ap:multiple-definitions="silence"/>
 	<tc:assert-xml>
 	  <S>b</S>
 	</tc:assert-xml>
@@ -182,8 +182,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:undefined-nonterminals="warning"/>
-	<ap:options ap:undefined-nonterminals="silence"/>
+	<tc:options ap:undefined-nonterminals="warning"/>
+	<tc:options ap:undefined-nonterminals="silence"/>
 	<tc:assert-xml>
 	  <ixml
 	    ><rule name="S"
@@ -240,8 +240,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:undefined-nonterminals="warning"/>
-	<ap:options ap:undefined-nonterminals="silence"/>
+	<tc:options ap:undefined-nonterminals="warning"/>
+	<tc:options ap:undefined-nonterminals="silence"/>
 	<tc:assert-not-a-sentence/>
       </tc:app-info>
     </tc:test-case>
@@ -252,8 +252,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:undefined-nonterminals="warning"/>
-	<ap:options ap:undefined-nonterminals="silence"/>
+	<tc:options ap:undefined-nonterminals="warning"/>
+	<tc:options ap:undefined-nonterminals="silence"/>
 	<tc:assert-xml>
 	  <S><A>a</A></S>
 	</tc:assert-xml>
@@ -266,8 +266,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:undefined-nonterminals="warning"/>
-	<ap:options ap:undefined-nonterminals="silence"/>	
+	<tc:options ap:undefined-nonterminals="warning"/>
+	<tc:options ap:undefined-nonterminals="silence"/>	
 	<tc:assert-xml>
 	  <S><B>b</B></S>
 	</tc:assert-xml><tc:assert-xml>
@@ -290,8 +290,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:undefined-nonterminals="warning"/>
-	<ap:options ap:undefined-nonterminals="silence"/>
+	<tc:options ap:undefined-nonterminals="warning"/>
+	<tc:options ap:undefined-nonterminals="silence"/>
 	<tc:assert-xml>
 	  <S>(<S>a</S>)</S>
 	</tc:assert-xml>
@@ -304,8 +304,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:undefined-nonterminals="warning"/>
-	<ap:options ap:undefined-nonterminals="silence"/>
+	<tc:options ap:undefined-nonterminals="warning"/>
+	<tc:options ap:undefined-nonterminals="silence"/>
 	<tc:assert-xml>
 	  <S>(<S>(<S>a</S>)</S>)</S>
 	</tc:assert-xml>
@@ -318,8 +318,8 @@
 	<tc:assert-not-a-grammar/>
       </tc:result>
       <tc:app-info>
-	<ap:options ap:undefined-nonterminals="warning"/>
-	<ap:options ap:undefined-nonterminals="silence"/>
+	<tc:options ap:undefined-nonterminals="warning"/>
+	<tc:options ap:undefined-nonterminals="silence"/>
 	<tc:assert-not-a-sentence/>
       </tc:app-info>
     </tc:test-case>


### PR DESCRIPTION
There are some places where `<ac:options>...</ac:options>` has been used instead of `<tc:options>...</tc:options>`.